### PR TITLE
Teleport config v2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ teleport_client_idle_timeout: "never"
 teleport_ssh_enabled: true
 teleport_ssh_listen_address: "0.0.0.0:3022"
 teleport_ssh_labels: '{{ hostvars[inventory_hostname].group_names[0] }}'
+teleport_additional_labels: {}
 
 teleport_proxy_enabled: false
 teleport_proxy_listener_mode: "separate"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ teleport_ssh_listen_address: "0.0.0.0:3022"
 teleport_ssh_labels: '{{ hostvars[inventory_hostname].group_names[0] }}'
 
 teleport_proxy_enabled: false
+teleport_proxy_listener_mode: "separate"
 teleport_proxy_listen_address: "0.0.0.0:3023"
 teleport_proxy_web_listen_address: "0.0.0.0:3080"
 teleport_proxy_tunnel_listen_address: "0.0.0.0:3024"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ teleport_state: started
 teleport_enabled: "yes"
 
 teleport_configuration_path: "/etc/teleport.yaml"
+teleport_configuration_version: v1
 
 teleport_nodename: "{{ ansible_fqdn }}"
 teleport_data_dir: "/var/lib/teleport"
@@ -40,7 +41,7 @@ teleport_auth_tokens_proxy: []
 teleport_auth_tokens_auth: []
 
 teleport_session_recording: "node"
-teleport_proxy_checks_host_keys: yes
+teleport_proxy_checks_host_keys: "yes"
 teleport_client_idle_timeout: "never"
 
 teleport_ssh_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,6 @@ teleport_proxy_listen_address: "0.0.0.0:3023"
 teleport_proxy_web_listen_address: "0.0.0.0:3080"
 teleport_proxy_web_fqdn: "{{ ansible_fqdn }}"
 teleport_proxy_tunnel_listen_address: "0.0.0.0:3024"
+
+teleport_proxy_acme_enabled: false
+teleport_proxy_acme_email: 'example@change.me'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,4 +52,5 @@ teleport_proxy_enabled: false
 teleport_proxy_listener_mode: "separate"
 teleport_proxy_listen_address: "0.0.0.0:3023"
 teleport_proxy_web_listen_address: "0.0.0.0:3080"
+teleport_proxy_web_fqdn: "{{ ansible_fqdn }}"
 teleport_proxy_tunnel_listen_address: "0.0.0.0:3024"

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -1,3 +1,5 @@
+#jinja2:lstrip_blocks: True
+---
 teleport:
   nodename: {{ teleport_nodename }}
 

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -101,6 +101,16 @@ proxy_service:
   listen_addr: {{ teleport_proxy_listen_address }} 
   tunnel_listen_addr: {{ teleport_proxy_tunnel_listen_address }}
   {% endif %}
+  {% if teleport_proxy_acme_enabled == true %}
+  # Get an automatic certificate from Letsencrypt.org using ACME via 
+  # TLS_ALPN-01 challenge.
+  # When using ACME, the cluster name must match the 'public_addr' of 
+  # Teleport and the 'proxy_service' must be publicly accessible over port 
+  # 443.
+  acme:
+    enabled: "yes"
+    email: {{ teleport_proxy_acme_email }}
+  {% endif %}
 {% else %}
   enabled: "no"
 {% endif %}

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -36,6 +36,9 @@ auth_service:
 {% if teleport_auth_enabled == true %}
   enabled: "yes"
   cluster_name: {{ teleport_auth_cluster_name }}
+  {% if teleport_configuration_version == "v2" %}
+  proxy_listener_mode: {{ teleport_proxy_listener_mode }}
+  {% endif %}
   authentication:
     type: local
     second_factor: {{ teleport_auth_second_factor }}
@@ -88,7 +91,10 @@ proxy_service:
   enabled: "yes"
   listen_addr: {{ teleport_proxy_listen_address }}
   web_listen_addr: {{ teleport_proxy_web_listen_address }}
+  {% if teleport_configuration_version == "v1" or teleport_proxy_listener_mode == "separate" %}
+  listen_addr: {{ teleport_proxy_listen_address }} 
   tunnel_listen_addr: {{ teleport_proxy_tunnel_listen_address }}
+  {% endif %}
 {% else %}
   enabled: "no"
 {% endif %}

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -82,6 +82,11 @@ ssh_service:
   listen_addr: {{ teleport_ssh_listen_address }}
   labels:
     group: {{ teleport_ssh_labels }}
+  {% if teleport_ssh_additional_labels|length > 0 %}
+  {% for label,value in teleport_ssh_additional_labels.items() %}
+    {{ label }}: {{ value }}
+  {% endfor %}
+  {% endif %}
 {% else %}
   enabled: "no"
 {% endif %}

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -1,5 +1,7 @@
 #jinja2:lstrip_blocks: True
 ---
+version: {{ teleport_configuration_version }}
+
 teleport:
   nodename: {{ teleport_nodename }}
 

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -47,7 +47,7 @@ auth_service:
       app_id: {{ teleport_u2f_app_id }}
       facets:
       {% for facet in teleport_u2f_facets %}
-      - {{ facet }}
+        - {{ facet }}
       {% endfor %}
 {% endif %}
   listen_addr: {{ teleport_auth_listen_address }}
@@ -94,7 +94,6 @@ ssh_service:
 proxy_service:
 {% if teleport_proxy_enabled == true %}
   enabled: "yes"
-  listen_addr: {{ teleport_proxy_listen_address }}
   web_listen_addr: {{ teleport_proxy_web_listen_address }}
   public_addr: {{ teleport_proxy_web_fqdn }}:443
   {% if teleport_configuration_version == "v1" or teleport_proxy_listener_mode == "separate" %}

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -91,6 +91,7 @@ proxy_service:
   enabled: "yes"
   listen_addr: {{ teleport_proxy_listen_address }}
   web_listen_addr: {{ teleport_proxy_web_listen_address }}
+  public_addr: {{ teleport_proxy_web_fqdn }}:443
   {% if teleport_configuration_version == "v1" or teleport_proxy_listener_mode == "separate" %}
   listen_addr: {{ teleport_proxy_listen_address }} 
   tunnel_listen_addr: {{ teleport_proxy_tunnel_listen_address }}


### PR DESCRIPTION
Add necessary variables and defaults to enable:
- v1 or v2 configuration
- TLS routing https://goteleport.com/docs/architecture/tls-routing/
- ACME certificates
- More than one label per node

Fix:
- jinja2 loop indent